### PR TITLE
allow usdc as denom

### DIFF
--- a/proposals/041-usdc-feeabs-disable.json
+++ b/proposals/041-usdc-feeabs-disable.json
@@ -1,0 +1,14 @@
+{
+    "messages": [
+        {
+            "@type": "/feeabstraction.feeabs.v1beta1.MsgRemoveHostZone",
+            "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+            "ibc_denom": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349"
+        }
+    ],
+    "title": "Remove $USDC IBC denomination to Host Zone",
+    "summary": "This proposal updates the fee abstraction module by removing support for $USDC from the Noble chain.",
+    "deposit": "5000000000uxion",
+    "expedited": true,
+    "metadata": ""
+}

--- a/proposals/042-globalfee-add-usdc.json
+++ b/proposals/042-globalfee-add-usdc.json
@@ -1,34 +1,37 @@
 {
-    "title": "Add Noble to globalfee module",
-    "description": "Add Noble to globalfee module",
-    "changes": [
+    "@type": "/cosmos.gov.v1.MsgSubmitProposal",
+    "messages": [
         {
-            "subspace": "globalfee",
-            "key": "MinimumGasPricesParam",
-            "value": [
-                {
-                    "denom": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
-                    "amount": "0.005000000000000000"
-                },
-                {
-                    "denom": "uxion",
-                    "amount": "0.001000000000000000"
-                }
-            ]
-        },
-        {
-            "subspace": "globalfee",
-            "key": "BypassMinFeeMsgTypes",
-            "value": [
-                "/xion.v1.MsgSend",
-                "/xion.v1.MsgMultiSend",
-                "/xion.jwk.v1.MsgDeleteAudience",
-                "/xion.jwk.v1.MsgDeleteAudienceClaim",
-                "/cosmos.authz.v1beta1.MsgRevoke",
-                "/cosmos.feegrant.v1beta1.MsgRevokeAllowance"
-            ]
+            "@type": "/cosmos.gov.v1.MsgExecLegacyContent",
+            "content": {
+                "@type": "/cosmos.params.v1beta1.ParameterChangeProposal",
+                "title": "Add Noble to globalfee module",
+                "description": "Add Noble to globalfee module",
+                "changes": [
+                    {
+                        "subspace": "globalfee",
+                        "key": "MinimumGasPricesParam",
+                        "value": "[{\"denom\":\"ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349\",\"amount\":\"0.005000000000000000\"},{\"denom\":\"uxion\",\"amount\":\"0.001000000000000000\"}]"
+                    },
+                    {
+                        "subspace": "globalfee",
+                        "key": "BypassMinFeeMsgTypes",
+                        "value": "[\"/xion.v1.MsgSend\",\"/xion.v1.MsgMultiSend\",\"/xion.jwk.v1.MsgDeleteAudience\",\"/xion.jwk.v1.MsgDeleteAudienceClaim\",\"/cosmos.authz.v1beta1.MsgRevoke\",\"/cosmos.feegrant.v1beta1.MsgRevokeAllowance\"]"
+                    }
+                ]
+            },
+            "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc"
         }
     ],
+    "initial_deposit": [
+        {
+            "denom": "uxion",
+            "amount": "5000000000"
+        }
+    ],
+    "title": "Add Noble to globalfee module",
+    "summary": "Add Noble to globalfee module",
     "deposit": "5000000000uxion",
-    "expedited": true
+    "expedited": true,
+    "metadata": ""
 }

--- a/proposals/042-globalfee-add-usdc.json
+++ b/proposals/042-globalfee-add-usdc.json
@@ -1,0 +1,34 @@
+{
+    "title": "Add Noble to globalfee module",
+    "description": "Add Noble to globalfee module",
+    "changes": [
+        {
+            "subspace": "globalfee",
+            "key": "MinimumGasPricesParam",
+            "value": [
+                {
+                    "denom": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
+                    "amount": "0.005000000000000000"
+                },
+                {
+                    "denom": "uxion",
+                    "amount": "0.001000000000000000"
+                }
+            ]
+        },
+        {
+            "subspace": "globalfee",
+            "key": "BypassMinFeeMsgTypes",
+            "value": [
+                "/xion.v1.MsgSend",
+                "/xion.v1.MsgMultiSend",
+                "/xion.jwk.v1.MsgDeleteAudience",
+                "/xion.jwk.v1.MsgDeleteAudienceClaim",
+                "/cosmos.authz.v1beta1.MsgRevoke",
+                "/cosmos.feegrant.v1beta1.MsgRevokeAllowance"
+            ]
+        }
+    ],
+    "deposit": "5000000000uxion",
+    "expedited": true
+}


### PR DESCRIPTION
## Description

Please include a detailed description of the changes being proposed in this pull request.

**Validators:**
- Who are you
- Nature and content of your gentx

## Type of Change

- [x] Governance Proposal
- [ ] Software Upgrade
- [ ] Parameter Change
- [ ] Contract Upload
- [ ] New Validator
- [ ] Bug fix
- [ ] Documentation update
- [ ] Tooling enhancement

## Testing

- [x] I've read [CONTRIBUTING.md](./CONTRIBUTING.md)

## Additional Information

This pull request introduces two new governance proposals in JSON format. The first proposal removes support for the $USDC IBC denomination from the fee abstraction module, while the second proposal adds Noble chain parameters to the global fee module.

Fee abstraction module updates:

* [`proposals/041-usdc-feeabs-disable.json`](diffhunk://#diff-254e3f4bb3b0f7345c8e8c1bd3df82c0357eafc5f182b917f07063c112bf9831R1-R14): Added a proposal to remove the $USDC IBC denomination from the Host Zone in the fee abstraction module. This change includes the removal of the `ibc_denom` and specifies a deposit of `5000000000uxion`.

Global fee module updates:

* [`proposals/042-globalfee-add-usdc.json`](diffhunk://#diff-c32f55bdc3bdc0fa22e0c708ad9ede0b1e11453c305f4119dc0aa4b28f240992R1-R34): Added a proposal to include Noble chain parameters in the global fee module. This change updates `MinimumGasPricesParam` with gas fees for $USDC and `uxion`, and specifies bypass message types for minimum fee requirements.
## Reviewers:

/assign @2xburnt
/assign @ash-burnt

Thank you for supporting the Burnt Networks!
