### PR TITLE
chore: fix CODEOWNERS team name casing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,6 @@
 # # Assign a role as a Code Owner:
 # /config/ @@maintainer
 
-* @burnt-labs/Burnt_Engineering/Burnt_Frontend
-* @burnt-labs/Burnt_Engineering/Burnt_Protocol
-.github/ @burnt-labs/Burnt_Engineering/Burnt_DevOps
+* @burnt-labs/burnt-engineering/burnt-frontend
+* @burnt-labs/burnt-engineering/burnt-protocol
+.github/ @burnt-labs/burnt-engineering/burnt-devops


### PR DESCRIPTION
Fixes team references in CODEOWNERS to use correct lowercase hyphenated slugs matching the actual GitHub team names:

- `burnt-engineering` (not `Burnt_Engineering`)  
- `burnt-devops` (not `Burnt_DevOps`)
- `burnt-protocol` (not `Burnt_Protocol`)
- `burnt-frontend` (not `Burnt_Frontend`)
- `burnt-zk` (not `Burnt_ZeroKnowledge`)

Without this fix, GitHub can't match the team references and CODEOWNERS review routing is broken.