### PR TITLE
chore: add v28.1.0 mainnet release and proposal

### DIFF
--- a/proposals/054-upgrade-v28.json
+++ b/proposals/054-upgrade-v28.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v28",
+        "height": "18912000",
+        "info": "https://raw.githubusercontent.com/burnt-labs/xion-mainnet-1/main/releases/v28.json",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "title": "Software Upgrade v28 - Security Enhancement",
+  "summary": "Software Upgrade v28 - Security Enhancement.",
+  "deposit": "1000000000uxion",
+  "expedited": false
+}

--- a/releases/v28.json
+++ b/releases/v28.json
@@ -1,0 +1,8 @@
+{
+  "binaries": {
+    "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_amd64.tar.gz?checksum=sha256:e71ae26b7234746232e03f58bfa384ff3a8d6bcc7bba7e1bb12a8f49d563b81b",
+    "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_arm64.tar.gz?checksum=sha256:dc5d69ea497ea6187e85d5952a2aed29687b9accddb23c993ae92da25e7df7d3",
+    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_amd64.tar.gz?checksum=sha256:9e69770f5d70979f6574ef466e5a39022f8ced73b6376913501d44f8d82f7454",
+    "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_arm64.tar.gz?checksum=sha256:a2a1ee3be6b23d51c86988ba42b307f60c80a15f4aac6b5d6adf46ef421f3519"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `releases/v28.json` with v28.1.0 binary URLs and SHA256 checksums
- Add `proposals/054-upgrade-v28.json` (upgrade applied at height 18912000)

## Context
Mainnet v28 upgrade (proposal 54 - "Software Upgrade v28 - Security Enhancement") was applied at height 18912000. This PR backfills the release and proposal files.

## Test plan
- [ ] Verify checksums match GitHub release assets
- [ ] Verify proposal height matches on-chain data

🤖 Generated with [Claude Code](https://claude.com/claude-code)