### PR TITLE
fix(ci): don't overwrite VERSION variable in checksums fetch

### DIFF
--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -53,17 +53,17 @@ cd "$(dirname "$0")/.."
 
 # Determine version from argument or calculate from latest release
 if [ -n "$RELEASE_TAG" ]; then
-    # Validate RELEASE_TAG format (should be like v22.0.0)
-    if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.0\.0$ ]]; then
-        echo "Error: RELEASE_TAG must be in format vX.0.0 (e.g., v22.0.0)"
+    # Validate RELEASE_TAG format (any valid semver: vX.Y.Z)
+    if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        echo "Error: RELEASE_TAG must be in semver format vX.Y.Z (e.g., v29.0.1)"
         echo "Provided: '$RELEASE_TAG'"
         exit 1
     fi
-    
+
     # Use RELEASE_TAG from argument (full version for content)
     VERSION_FULL="$RELEASE_TAG"
-    VERSION_NUM=$(echo "$VERSION_FULL" | sed 's/v\([0-9]*\)\.0\.0/\1/')
-    # Create short version for filenames (v22 instead of v22.0.0)
+    VERSION_NUM=$(echo "$VERSION_FULL" | sed -E 's/^v([0-9]+)\..*/\1/')
+    # Create short version for filenames (v29 instead of v29.0.1)
     VERSION="v${VERSION_NUM}"
     echo "Using specified version: $VERSION_FULL (files will use: $VERSION)"
 else

--- a/scripts/orchestrate-release.sh
+++ b/scripts/orchestrate-release.sh
@@ -80,8 +80,8 @@ calculate_upgrade_height() {
 fetch_release_checksums() {
   echo "📋 Fetching release checksums..."
 
-  VERSION="${RELEASE_TAG#v}"
-  CHECKSUMS_URL="https://github.com/burnt-labs/xion/releases/download/$RELEASE_TAG/xiond-${VERSION}-checksums.txt"
+  local RELEASE_VERSION="${RELEASE_TAG#v}"
+  CHECKSUMS_URL="https://github.com/burnt-labs/xion/releases/download/$RELEASE_TAG/xiond-${RELEASE_VERSION}-checksums.txt"
   HTTP_CODE=$(curl -sL -w "%{http_code}" "$CHECKSUMS_URL" -o checksums_temp.txt)
 
   if [ "${HTTP_CODE: -3}" = "200" ]; then


### PR DESCRIPTION
fetch_release_checksums was clobbering the global VERSION (v29) with the full semver (29.0.1), causing file path mismatches downstream.