### PR TITLE
feat(ci): auto-merge upgrade PR to main

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -32,6 +32,10 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   create-release-pr:
     runs-on: ubicloud-standard-2

--- a/scripts/orchestrate-release.sh
+++ b/scripts/orchestrate-release.sh
@@ -329,7 +329,8 @@ commit_and_push_pr() {
   if [ -n "$EXISTING_PR" ] && [ "$EXISTING_PR" != "null" ]; then
     echo "Updating existing PR #$EXISTING_PR"
     gh pr edit "$EXISTING_PR" --repo "$REPO" --body-file pr_body.md
-    echo "✅ Updated PR #$EXISTING_PR"
+    PR_NUMBER="$EXISTING_PR"
+    echo "✅ Updated PR #$PR_NUMBER"
   else
     echo "Creating new PR"
     gh pr create \
@@ -338,8 +339,27 @@ commit_and_push_pr() {
       --head "$BRANCH_NAME" \
       --title "🚀 Upgrade to Xion $RELEASE_TAG" \
       --body-file pr_body.md
-    echo "✅ PR created successfully"
+    PR_NUMBER=$(gh pr list --repo "$REPO" --head "$BRANCH_NAME" --base "$TARGET_BRANCH" --json number --jq '.[0].number')
+    echo "✅ PR #$PR_NUMBER created"
   fi
+
+  # Squash-merge the PR (API merge produces a signed commit; linear history required by ruleset)
+  echo "📋 Merging PR #$PR_NUMBER to $TARGET_BRANCH..."
+  MERGE_RESPONSE=$(gh api \
+    -X PUT \
+    "repos/${REPO}/pulls/${PR_NUMBER}/merge" \
+    -f "merge_method=squash" \
+    -f "commit_title=🚀 Upgrade to Xion $RELEASE_TAG (#${PR_NUMBER})" 2>&1) || {
+      echo "⚠️  Merge failed:"
+      echo "$MERGE_RESPONSE"
+      echo "PR #$PR_NUMBER left open for manual review"
+      rm -f commit_message.txt
+      return 0
+    }
+  echo "✅ PR #$PR_NUMBER merged to $TARGET_BRANCH"
+
+  # Delete the upgrade branch after merge
+  gh api -X DELETE "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" 2>/dev/null || true
 
   rm -f commit_message.txt
 }

--- a/scripts/orchestrate-release.sh
+++ b/scripts/orchestrate-release.sh
@@ -353,7 +353,7 @@ commit_and_push_pr() {
       echo "⚠️  Merge failed:"
       echo "$MERGE_RESPONSE"
       echo "PR #$PR_NUMBER left open for manual review"
-      return 0
+      return 1
     }
   echo "✅ PR #$PR_NUMBER merged to $TARGET_BRANCH"
 

--- a/scripts/orchestrate-release.sh
+++ b/scripts/orchestrate-release.sh
@@ -353,15 +353,12 @@ commit_and_push_pr() {
       echo "⚠️  Merge failed:"
       echo "$MERGE_RESPONSE"
       echo "PR #$PR_NUMBER left open for manual review"
-      rm -f commit_message.txt
       return 0
     }
   echo "✅ PR #$PR_NUMBER merged to $TARGET_BRANCH"
 
   # Delete the upgrade branch after merge
   gh api -X DELETE "repos/${REPO}/git/refs/heads/${BRANCH_NAME}" 2>/dev/null || true
-
-  rm -f commit_message.txt
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Squash-merges the upgrade PR via the GitHub API after creation
- API merge produces a signed commit satisfying the main branch ruleset
- Deletes the upgrade branch after merge
- Adds permissions block (contents: write, pull-requests: write)

## Downstream workflows
After merge, any push-to-main workflows on this repo will fire naturally.

## Question for reviewer
Are there specific downstream workflows you want triggered (e.g., on a different repo, or via repository_dispatch)? If so, I can add them.