### PR TITLE
fix(releases): real sha256 checksums + correct filenames for v29.json

### DIFF
--- a/releases/v29.json
+++ b/releases/v29.json
@@ -1,8 +1,8 @@
 {
   "binaries": {
-    "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.0_darwin_amd64.tar.gz?checksum=sha256:--ADD-HERE-YOUR-VALUE--",
-    "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.0_darwin_arm64.tar.gz?checksum=sha256:--ADD-HERE-YOUR-VALUE--",
-    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.0_linux_amd64.tar.gz?checksum=sha256:--ADD-HERE-YOUR-VALUE--",
-    "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.0_linux_arm64.tar.gz?checksum=sha256:--ADD-HERE-YOUR-VALUE--"
+    "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.1_darwin_amd64.tar.gz?checksum=sha256:bdf7ecd3aa136f19eadd46480a4dc1898381d07751ff4091bd624f1eb341a809",
+    "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.1_darwin_arm64.tar.gz?checksum=sha256:cb0a29c8135c9348744fcbaa4ea794cc417f708e46abe1c1db099bbcb7d1601f",
+    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.1_linux_amd64.tar.gz?checksum=sha256:c00a269695f32ccd1fbe54f3d7db506fe8576373ece7a54f7e46f423ab4c3312",
+    "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.1/xiond_29.0.1_linux_arm64.tar.gz?checksum=sha256:33724370cde672d2d6f7d7ca45c54241c15d714e258559b8cab7c37a4a5d40bf"
   }
 }


### PR DESCRIPTION
Fixes [`releases/v29.json`](https://github.com/burnt-labs/xion-mainnet-1/blob/main/releases/v29.json), which shipped with two defects:

1. **Placeholder checksums** — all four `sha256:` values were `--ADD-HERE-YOUR-VALUE--`.
2. **Wrong filenames** — binary filenames were pinned to `xiond_29.0.0_*` while the release tag in the URL is `v29.0.1`. No `29.0.0` assets exist under that tag.

## What changed
- Replaced placeholders with the real sha256 checksums from the [v29.0.1 release](https://github.com/burnt-labs/xion/releases/tag/v29.0.1) (`xiond-29.0.1-checksums.txt`).
- Corrected filenames `xiond_29.0.0_*` → `xiond_29.0.1_*`.

## Verification
- All four checksums verified against the published `v29.0.1` release assets.
- JSON validated.

| Platform | sha256 |
|---|---|
| darwin/amd64 | `bdf7ecd3aa136f19eadd46480a4dc1898381d07751ff4091bd624f1eb341a809` |
| darwin/arm64 | `cb0a29c8135c9348744fcbaa4ea794cc417f708e46abe1c1db099bbcb7d1601f` |
| linux/amd64  | `c00a269695f32ccd1fbe54f3d7db506fe8576373ece7a54f7e46f423ab4c3312` |
| linux/arm64  | `33724370cde672d2d6f7d7ca45c54241c15d714e258559b8cab7c37a4a5d40bf` |

## Notes / rollback
- The v29 upgrade (height `20830000`) is **already past**, so this is a correctness fix — it makes the pinned config match the real published artifacts. No active upgrade is affected.
- Rollback: revert this single-file change.

## Follow-up (not in this PR)
The release-automation bot is emitting these `--ADD-HERE--` placeholders for each release config (same issue hit `releases/v30.json`). Worth fixing the generator so it substitutes real checksums at cut time. Happy to file a separate issue/PR on the workflow.