### PR TITLE
fix(release): never ship placeholders in upgrade PRs

### DIFF
--- a/.github/workflows/prompts/claude-api-prompt.md
+++ b/.github/workflows/prompts/claude-api-prompt.md
@@ -1,6 +1,6 @@
 You are a technical writer for the Xion blockchain project. Please analyze the GitHub comparison data and create a comprehensive upgrade guide document for version {{RELEASE_TAG}}, similar to professional blockchain upgrade documentation.
 
-**Important**: This may be a future release where the binary doesn't exist yet. If the comparison data shows "TBD" values or mentions it's a future release, create documentation that acknowledges this and provides appropriate placeholders and preparation instructions.
+**Important**: The release is already published before this document is generated. Use only real information drawn from the GitHub comparison data (actual PR numbers, commit messages, and contributor usernames). Do NOT emit placeholder tokens such as `--ADD-HERE-...--`, bracketed `[fill in ...]` stubs, or `{{TEMPLATE}}` variables in your output — every such token will fail the release validation gate. If a section has no corresponding changes in the comparison data, omit that section entirely rather than leaving a placeholder.
 
 Format the document as a detailed upgrade guide with the following structure:
 

--- a/.github/workflows/templates/release_notes_template.md
+++ b/.github/workflows/templates/release_notes_template.md
@@ -2,28 +2,11 @@
 
 ## Overview
 
-The Xion {{RELEASE_TAG}} series includes [--ADD-HERE-OVERVIEW-DESCRIPTION--]. This is the initial release with only {{RELEASE_TAG}} available.
+This release upgrades the chain to Xion {{RELEASE_TAG}}. See the full changelog below for the complete list of changes.
 
 ## What's Changed
 
-### {{RELEASE_TAG}} (Only Version)
-
-#### WebAuthn & Authentication
-- **[--ADD-HERE-WEBAUTHN-FEATURE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### CosmWasm & Module Updates
-- **[--ADD-HERE-COSMWASM-UPDATE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Protocol & Core Changes
-- **[--ADD-HERE-PROTOCOL-CHANGE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Bug Fixes & Improvements
-- **[--ADD-HERE-BUG-FIX--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-- **[--ADD-HERE-IMPROVEMENT--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Code Quality & Testing
-- **[--ADD-HERE-TEST-UPDATE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-- **[--ADD-HERE-CODE-QUALITY--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
+See the [full changelog](https://github.com/burnt-labs/xion/compare/{{PREVIOUS_VERSION}}...{{RELEASE_TAG}}) for the complete list of commits and pull requests in this release.
 
 ## Upgrade Information
 
@@ -34,14 +17,6 @@ The Xion {{RELEASE_TAG}} series includes [--ADD-HERE-OVERVIEW-DESCRIPTION--]. Th
 ## Release Links
 
 - **{{RELEASE_TAG}}**: [GitHub Release](https://github.com/burnt-labs/xion/releases/tag/{{RELEASE_TAG}})
-
-## Contributors
-
-Special thanks to the following contributors who made this release possible:
-
-- [@--ADD-HERE-CONTRIBUTOR-1--](https://github.com/--ADD-HERE-CONTRIBUTOR-1--)
-- [@--ADD-HERE-CONTRIBUTOR-2--](https://github.com/--ADD-HERE-CONTRIBUTOR-2--)
-- [@--ADD-HERE-CONTRIBUTOR-3--](https://github.com/--ADD-HERE-CONTRIBUTOR-3--)
 
 ## Full Changelog
 

--- a/scripts/create-release-pr.sh
+++ b/scripts/create-release-pr.sh
@@ -199,13 +199,17 @@ fi
 
 if [ "$SHOULD_UPDATE_RELEASE" = true ]; then
     echo "Creating/updating release file: $RELEASE_FILE"
+    # Binary asset filenames match the full release version (e.g. 29.0.1),
+    # not ${VERSION_NUM}.0.0 — using .0.0 produced broken URLs like
+    # xiond_29.0.0_* under the v29.0.1 tag where no such asset exists.
+    RELEASE_VERSION_NUM="${VERSION_FULL#v}"
     cat > "$RELEASE_FILE" << EOF
 {
     "binaries": {
-        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${VERSION_NUM}.0.0_darwin_amd64.tar.gz?checksum=sha256:${DARWIN_AMD64_CHECKSUM}",
-        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${VERSION_NUM}.0.0_darwin_arm64.tar.gz?checksum=sha256:${DARWIN_ARM64_CHECKSUM}",
-        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${VERSION_NUM}.0.0_linux_amd64.tar.gz?checksum=sha256:${LINUX_AMD64_CHECKSUM}",
-        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${VERSION_NUM}.0.0_linux_arm64.tar.gz?checksum=sha256:${LINUX_ARM64_CHECKSUM}"
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${RELEASE_VERSION_NUM}_darwin_amd64.tar.gz?checksum=sha256:${DARWIN_AMD64_CHECKSUM}",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${RELEASE_VERSION_NUM}_darwin_arm64.tar.gz?checksum=sha256:${DARWIN_ARM64_CHECKSUM}",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${RELEASE_VERSION_NUM}_linux_amd64.tar.gz?checksum=sha256:${LINUX_AMD64_CHECKSUM}",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/${VERSION_FULL}/xiond_${RELEASE_VERSION_NUM}_linux_arm64.tar.gz?checksum=sha256:${LINUX_ARM64_CHECKSUM}"
     }
 }
 EOF
@@ -270,28 +274,11 @@ if [ "$SHOULD_UPDATE_RELEASE_NOTES" = true ]; then
 
 ## Overview
 
-The Xion {{RELEASE_TAG}} series includes [--ADD-HERE-OVERVIEW-DESCRIPTION--]. This is the initial release with only {{RELEASE_TAG}} available.
+This release upgrades the chain to Xion {{RELEASE_TAG}}. See the full changelog below for the complete list of changes.
 
 ## What's Changed
 
-### {{RELEASE_TAG}} (Only Version)
-
-#### WebAuthn & Authentication
-- **[--ADD-HERE-WEBAUTHN-FEATURE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### CosmWasm & Module Updates
-- **[--ADD-HERE-COSMWASM-UPDATE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Protocol & Core Changes
-- **[--ADD-HERE-PROTOCOL-CHANGE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Bug Fixes & Improvements
-- **[--ADD-HERE-BUG-FIX--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-- **[--ADD-HERE-IMPROVEMENT--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-
-#### Code Quality & Testing
-- **[--ADD-HERE-TEST-UPDATE--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
-- **[--ADD-HERE-CODE-QUALITY--]**: [--ADD-HERE-DESCRIPTION--] by [@--ADD-HERE-USERNAME--](https://github.com/--ADD-HERE-USERNAME--) in [#--ADD-HERE-PR-NUMBER--](https://github.com/burnt-labs/xion/pull/--ADD-HERE-PR-NUMBER--)
+See the [full changelog](https://github.com/burnt-labs/xion/compare/{{PREVIOUS_VERSION}}...{{RELEASE_TAG}}) for the complete list of commits and pull requests in this release.
 
 ## Upgrade Information
 
@@ -302,14 +289,6 @@ The Xion {{RELEASE_TAG}} series includes [--ADD-HERE-OVERVIEW-DESCRIPTION--]. Th
 ## Release Links
 
 - **{{RELEASE_TAG}}**: [GitHub Release](https://github.com/burnt-labs/xion/releases/tag/{{RELEASE_TAG}})
-
-## Contributors
-
-Special thanks to the following contributors who made this release possible:
-
-- [@--ADD-HERE-CONTRIBUTOR-1--](https://github.com/--ADD-HERE-CONTRIBUTOR-1--)
-- [@--ADD-HERE-CONTRIBUTOR-2--](https://github.com/--ADD-HERE-CONTRIBUTOR-2--)
-- [@--ADD-HERE-CONTRIBUTOR-3--](https://github.com/--ADD-HERE-CONTRIBUTOR-3--)
 
 ## Full Changelog
 

--- a/scripts/orchestrate-release.sh
+++ b/scripts/orchestrate-release.sh
@@ -85,24 +85,38 @@ fetch_release_checksums() {
   CHECKSUMS_URL="https://github.com/burnt-labs/xion/releases/download/$RELEASE_TAG/xiond-${RELEASE_VERSION}-checksums.txt"
   HTTP_CODE=$(curl -sL -w "%{http_code}" "$CHECKSUMS_URL" -o checksums_temp.txt)
 
-  if [ "${HTTP_CODE: -3}" = "200" ]; then
-    DARWIN_AMD64_CHECKSUM=$(grep "darwin_amd64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
-    DARWIN_ARM64_CHECKSUM=$(grep "darwin_arm64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
-    LINUX_AMD64_CHECKSUM=$(grep "linux_amd64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
-    LINUX_ARM64_CHECKSUM=$(grep "linux_arm64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
-    echo "✅ Real checksums fetched"
-  else
-    echo "⚠️  Checksums not available for $RELEASE_TAG (HTTP ${HTTP_CODE: -3})"
-    echo "    This is expected for future releases not yet published"
+  if [ "${HTTP_CODE: -3}" != "200" ]; then
+    echo "❌ ERROR: Checksums not available for $RELEASE_TAG (HTTP ${HTTP_CODE: -3})"
     echo "    URL: $CHECKSUMS_URL"
-    DARWIN_AMD64_CHECKSUM="$PLACEHOLDER_CHECKSUM"
-    DARWIN_ARM64_CHECKSUM="$PLACEHOLDER_CHECKSUM"
-    LINUX_AMD64_CHECKSUM="$PLACEHOLDER_CHECKSUM"
-    LINUX_ARM64_CHECKSUM="$PLACEHOLDER_CHECKSUM"
-    echo "    Using placeholder checksums"
+    echo "    The GitHub release must be published before cutting the upgrade"
+    echo "    proposal PR. Refusing to generate placeholder checksums."
+    rm -f checksums_temp.txt
+    exit 1
   fi
 
+  DARWIN_AMD64_CHECKSUM=$(grep "darwin_amd64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
+  DARWIN_ARM64_CHECKSUM=$(grep "darwin_arm64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
+  LINUX_AMD64_CHECKSUM=$(grep "linux_amd64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
+  LINUX_ARM64_CHECKSUM=$(grep "linux_arm64\.tar\.gz$" checksums_temp.txt | awk '{print $1}')
   rm -f checksums_temp.txt
+
+  # Every checksum must be a real 64-char hex sha256, never empty or a placeholder.
+  local sha_re='^[0-9a-f]{64}$'
+  for pair in \
+    "darwin/amd64:$DARWIN_AMD64_CHECKSUM" \
+    "darwin/arm64:$DARWIN_ARM64_CHECKSUM" \
+    "linux/amd64:$LINUX_AMD64_CHECKSUM" \
+    "linux/arm64:$LINUX_ARM64_CHECKSUM"; do
+    platform="${pair%%:*}"
+    value="${pair#*:}"
+    if [[ ! "$value" =~ $sha_re ]]; then
+      echo "❌ ERROR: Invalid or missing sha256 for $platform: '$value'"
+      echo "    Expected a 64-char hex digest from $CHECKSUMS_URL"
+      exit 1
+    fi
+  done
+
+  echo "✅ Real checksums fetched and validated"
 }
 
 fetch_github_comparison() {
@@ -230,6 +244,38 @@ substitute_release_notes() {
     sed -i "s|{{VERSION}}|$VERSION|g" "$RELEASE_NOTES_FILE"
     echo "✅ Template variables substituted"
   fi
+}
+
+validate_no_placeholders() {
+  echo "📋 Validating generated files contain no placeholders..."
+
+  local errors=0
+  for file in "$PROPOSAL_FILE" "$RELEASE_FILE" "$RELEASE_NOTES_FILE"; do
+    [ -f "$file" ] || continue
+    # Reject leftover ADD-HERE placeholders and unsubstituted {{TEMPLATE}} vars.
+    if grep -nE 'ADD-HERE|\{\{[A-Z_]+\}\}' "$file" >/dev/null 2>&1; then
+      echo "❌ ERROR: $file still contains placeholders/unsubstituted variables:"
+      grep -nE 'ADD-HERE|\{\{[A-Z_]+\}\}' "$file" | sed 's/^/      /'
+      errors=$((errors + 1))
+    fi
+  done
+
+  # Release file must carry four real sha256 digests.
+  if [ -f "$RELEASE_FILE" ]; then
+    local sha_count
+    sha_count=$(grep -oE 'checksum=sha256:[0-9a-f]{64}' "$RELEASE_FILE" | wc -l | tr -d ' ')
+    if [ "$sha_count" -ne 4 ]; then
+      echo "❌ ERROR: $RELEASE_FILE has $sha_count valid sha256 checksums, expected 4"
+      errors=$((errors + 1))
+    fi
+  fi
+
+  if [ "$errors" -ne 0 ]; then
+    echo "❌ Aborting before commit: placeholder/validation check failed ($errors file(s))."
+    exit 1
+  fi
+
+  echo "✅ No placeholders found in generated files"
 }
 
 generate_pr_body() {
@@ -386,6 +432,7 @@ main() {
   create_release_files
   determine_file_paths
   substitute_release_notes
+  validate_no_placeholders
   generate_pr_body
   commit_and_push_pr
 


### PR DESCRIPTION
The release-automation pipeline could produce upgrade PRs containing `--ADD-HERE-YOUR-VALUE--` checksum placeholders, unfilled release-note skeletons, and wrong binary filenames — and then **auto-merge them to `main`**. This is what produced the bad [`releases/v29.json`](https://github.com/burnt-labs/xion-mainnet-1/blob/main/releases/v29.json) and the placeholders we just fixed on [PR #26](https://github.com/burnt-labs/xion-mainnet-1/pull/26).

## Root causes & fixes

### 1. Silent checksum fallback → hard fail
`fetch_release_checksums()` in `orchestrate-release.sh` fell back to placeholder checksums and **continued** when the GitHub release wasn't published yet. Now it:
- Exits `1` on any non-200 from the checksums URL (the release must be published before cutting the proposal PR).
- Validates each fetched value is a real 64-char hex sha256.

### 2. Wrong binary filenames
`create-release-pr.sh` hardcoded `xiond_<major>.0.0_*` in the release URLs, producing broken links like `xiond_29.0.0_*` under the `v29.0.1` tag (no such asset exists). Now uses the full release version (`${VERSION_FULL#v}`) → `xiond_29.0.1_*`.

### 3. Placeholder release notes + no guard
- The default skeleton (inline in `create-release-pr.sh` **and** `templates/release_notes_template.md`) was full of `--ADD-HERE--` stubs. Replaced both with a minimal, fully-substituted template (overview + changelog compare link + upgrade info).
- The AI prompt (`prompts/claude-api-prompt.md`) explicitly asked the model to emit placeholders/TBD for "future releases" — updated to **forbid** placeholder tokens and use only real comparison data.
- Added a **`validate_no_placeholders()` gate** that runs after generation and **before commit/merge**. It aborts the run if any file still contains an `ADD-HERE` token, an unsubstituted `{{TEMPLATE}}` variable, or fewer than 4 valid sha256 checksums.

## Verification
- **End-to-end simulation** with the real v30.0.0 inputs: produced a clean `releases/v30.json` (correct `xiond_30.0.0_*` filenames + real checksums) and fully-substituted notes; the gate **passes**.
- **Negative tests**: `fetch_release_checksums` exits `1` on a nonexistent tag (HTTP 404); the gate **fails** on a placeholder checksum and on an unsubstituted template var.
- `bash -n` syntax-clean on both scripts.

## Files changed
- `scripts/orchestrate-release.sh` — hard-fail checksum fetch + validation gate
- `scripts/create-release-pr.sh` — correct filenames + de-placeholdered default skeleton
- `.github/workflows/templates/release_notes_template.md` — clean fallback template
- `.github/workflows/prompts/claude-api-prompt.md` — forbid placeholder output

## Rollback
Revert this commit; the pipeline returns to its prior (placeholder-tolerant) behavior.

## Related
- [PR #26](https://github.com/burnt-labs/xion-mainnet-1/pull/26) — fixed the v30 placeholders/notes by hand
- [PR #27](https://github.com/burnt-labs/xion-mainnet-1/pull/27) — fixed the historical `releases/v29.json`