### PR TITLE
🚀 Upgrade to Xion v30.0.0

### DIFF
--- a/proposals/058-upgrade-v30.json
+++ b/proposals/058-upgrade-v30.json
@@ -1,0 +1,18 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.upgrade.v1beta1.MsgSoftwareUpgrade",
+      "authority": "xion10d07y265gmmuvt4z0w9aw880jnsr700jctf8qc",
+      "plan": {
+        "name": "v30",
+        "height": "21889000",
+        "info": "https://raw.githubusercontent.com/burnt-labs/xion-mainnet-1/main/releases/v30.json",
+        "upgraded_client_state": null
+      }
+    }
+  ],
+  "title": "Software Upgrade v30",
+  "summary": "Software Upgrade v30",
+  "deposit": "1000000000uxion",
+  "expedited": false
+}

--- a/release_notes/v30.md
+++ b/release_notes/v30.md
@@ -1,0 +1,40 @@
+# Xion v30.0.0 Release Notes
+
+## Overview
+
+Xion v30.0.0 completes the "Verona" branding rename across the codebase and API documentation, sets the `v30` upgrade constant, and removes legacy leaked-key testnet code. This is an in-place chain upgrade for `xion-mainnet-1`.
+
+## What's Changed
+
+### v30.0.0
+
+#### Protocol & Core Changes
+- **Verona branding & v30 upgrade**: Set the upgrade name constant to `v30` in `app/upgrades.go`, renamed all "Xion" references to "Verona" across documentation, OpenAPI, and Swagger files, and removed legacy testnet code tied to a leaked private key by [@2xburnt](https://github.com/2xburnt) in [#570](https://github.com/burnt-labs/xion/pull/570)
+
+#### Documentation
+- **Docs operationId rename**: Renamed remaining `Xion*` operationIds to `Verona*` in the API docs by [@Copilot](https://github.com/Copilot) in [#572](https://github.com/burnt-labs/xion/pull/572)
+
+## Upgrade Information
+
+- **Upgrade Height**: [21889000](https://www.mintscan.io/xion/block/21889000) (xion-mainnet-1, ~8:00 AM EDT 2026-06-17)
+- **Proposal Number**: [58](https://www.mintscan.io/xion/proposals/58)
+- **Upgrade Name**: [v30](https://github.com/burnt-labs/xion-mainnet-1/blob/main/proposals/058-upgrade-v30.json)
+
+## Release Links
+
+- **v30.0.0**: [GitHub Release](https://github.com/burnt-labs/xion/releases/tag/v30.0.0)
+
+## Contributors
+
+Special thanks to the following contributors who made this release possible:
+
+- [@2xburnt](https://github.com/2xburnt)
+- [@Copilot](https://github.com/Copilot)
+
+## Full Changelog
+
+[v29.0.1...v30.0.0](https://github.com/burnt-labs/xion/compare/v29.0.1...v30.0.0)
+
+---
+
+For more information about the upgrade process, please refer to the [upgrade proposal](../proposals/058-upgrade-v30.json).

--- a/releases/v30.json
+++ b/releases/v30.json
@@ -1,0 +1,8 @@
+{
+  "binaries": {
+    "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v30.0.0/xiond_30.0.0_darwin_amd64.tar.gz?checksum=sha256:06564d41f0da4a37c7c4f6a40809699bcf208b47d62a493a336eb74cb0fb8f54",
+    "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v30.0.0/xiond_30.0.0_darwin_arm64.tar.gz?checksum=sha256:84b0ef5bdb21cccd518eeb2fd97ee6f2933de8b38f36e53fa034b970833d47b2",
+    "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v30.0.0/xiond_30.0.0_linux_amd64.tar.gz?checksum=sha256:e723661ce690868410ebf995efb84c26d8b418992ef2d475ab7f27cd969000ae",
+    "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v30.0.0/xiond_30.0.0_linux_arm64.tar.gz?checksum=sha256:fb470639317ef4fc04082afb3ba667f108ea8c2a2c41d122781e8191134076a3"
+  }
+}


### PR DESCRIPTION
## 🚀 Xion v30.0.0 Mainnet Upgrade

In-place chain upgrade for `xion-mainnet-1` to [v30.0.0](https://github.com/burnt-labs/xion/releases/tag/v30.0.0).

## Upgrade Details
- **Upgrade Height**: [21889000](https://www.mintscan.io/xion/block/21889000) — ~8:00 AM EDT / 12:00 UTC on 2026-06-17
- **Chain ID**: `xion-mainnet-1` (in-place migration)
- **Proposal**: [58](https://www.mintscan.io/xion/proposals/58) (`proposals/058-upgrade-v30.json`)
- **Deposit**: 1000000000uxion · **Expedited**: false
- **Release**: [v30.0.0](https://github.com/burnt-labs/xion/releases/tag/v30.0.0) · [compare v29.0.1...v30.0.0](https://github.com/burnt-labs/xion/compare/v29.0.1...v30.0.0)

## Files
- `proposals/058-upgrade-v30.json` — the governance proposal
- `releases/v30.json` — binary URLs + **real** sha256 checksums (verified against the release)
- `release_notes/v30.md` — changelog (#570, #572)

## Checksums (verified against the v30.0.0 release)
- darwin/amd64: `06564d41f0da4a37c7c4f6a40809699bcf208b47d62a493a336eb74cb0fb8f54`
- darwin/arm64: `84b0ef5bdb21cccd518eeb2fd97ee6f2933de8b38f36e53fa034b970833d47b2`
- linux/amd64: `e723661ce690868410ebf995efb84c26d8b418992ef2d475ab7f27cd969000ae`
- linux/arm64: `fb470639317ef4fc04082afb3ba667f108ea8c2a2c41d122781e8191134076a3`

Commit authored by 2xburnt, co-authored by Crucible, signed.